### PR TITLE
added logger override, remove puts line

### DIFF
--- a/app/controllers/spree/api/v1/mollie_controller.rb
+++ b/app/controllers/spree/api/v1/mollie_controller.rb
@@ -6,8 +6,6 @@ module Spree
           mollie = Spree::PaymentMethod.find_by_type 'Spree::Gateway::MollieGateway'
           payment_methods = mollie.available_payment_methods
 
-          puts payment_methods
-
           render json: payment_methods
         end
       end

--- a/app/models/spree/mollie_logger.rb
+++ b/app/models/spree/mollie_logger.rb
@@ -5,5 +5,9 @@ module Spree
       @logger ||= Logger.new(File.join(Rails.root, 'log', 'mollie.log'))
       @logger.debug(message)
     end
+
+    def self.logger=(logger)
+      @logger = logger
+    end
   end
 end


### PR DESCRIPTION
I checked the code and saw a left over puts method and I added a way to set override the MollieLogger.
This would be helpful if you want to see the MollieLogging in a Docker environment.
You can easily specify Spree::MollieLogger.logger = Rails.logger and use the configuration from rails to route it to STDOUT or syslog logging.

The only other concern I have is the order_decorator.rb

```ruby
Spree::Order.class_eval do
  # Make sure the order confirmation is delivered when the order has been paid for.
  def finalize!
    # lock all adjustments (coupon promotions, etc.)
    all_adjustments.each(&:close)

    # update payment and shipment(s) states, and save
    updater.update_payment_state
    shipments.each do |shipment|
      shipment.update!(self)
      shipment.finalize!
    end

    updater.update_shipment_state
    save!
    updater.run_hooks

    touch :completed_at

    deliver_order_confirmation_email unless confirmation_delivered? or !paid?

    consider_risk
  end
end
```

I see a lot of methods that look like database calls, but there is no real database locking or transactions in place.
Especially with webhooks triggering this method, this could potentially lead to inconsistency in the database. For instance if the first webhook call fails, mollie will retry and call the same functions again. I see spree heavily relies on a state machine that could prevent further updates on the order.

Looking at the update_by_mollie_status! method, it probably a good idea to wrap this function in a transaction.

```ruby
def update_by_mollie_status!(mollie_payment, payment)
  payment.transaction do
    case mollie_payment.status
      when 'paid'
        payment.complete! unless payment.completed?
        payment.order.finalize!
        payment.order.update_attributes(:state => 'complete', :completed_at => Time.now)
      when 'cancelled', 'expired', 'failed'
        payment.failure! unless payment.failed?
      when 'refunded'
        payment.void! unless payment.void?
      else
        MollieLogger.debug('Unhandled Mollie payment state received. Therefore we did not update the payment state.')
    end
  
    payment.source.update(status: payment.state)
  end
end
```

 

