### PR TITLE
Update mollie-api-ruby to 3.1.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'mollie-api-ruby', '~> 3.1.4.pre.beta'
+gem 'mollie-api-ruby', '~> 3.1.4'
 
 # Specify your gem's dependencies in spree_mollie_gateway.gemspec
 gemspec

--- a/spree_mollie_gateway.gemspec
+++ b/spree_mollie_gateway.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coffee-rails'
   spec.add_development_dependency 'database_cleaner'
 
-  spec.add_runtime_dependency 'mollie-api-ruby', '~> 3.1', '>= 3.1.4.pre.beta'
+  spec.add_runtime_dependency 'mollie-api-ruby', '~> 3.1', '>= 3.1.4'
 end


### PR DESCRIPTION
Update `mollie-api-ruby` runtime dependency to `3.1.4`.

I'll prepare a `1.0.5` release after merging.