### PR TITLE
Multicurrency support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'mollie-api-ruby', :git => 'git://github.com/mollie/mollie-api-ruby.git', :branch => 'mollie-v2'
+gem 'mollie-api-ruby', '~> 4.0.0-alpha.1'
 
 # Specify your gem's dependencies in spree_mollie_gateway.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'mollie-api-ruby', '~> 3.1.4'
+gem 'mollie-api-ruby', :git => 'git://github.com/mollie/mollie-api-ruby.git', :branch => 'mollie-v2'
 
 # Specify your gem's dependencies in spree_mollie_gateway.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'mollie-api-ruby', '~> 4.0.0-alpha.1'
+gem 'mollie-api-ruby', '~> 4.0.0'
 
 # Specify your gem's dependencies in spree_mollie_gateway.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ bundle exec rails g spree_mollie_gateway:install
 ## API endpoints
 This gateway comes with a couple of API endpoints which seamlessly integrate with the Spree API.
 
-<a href="docs/api">Overview of available API endpoints.</a>  
+- <a href="docs/api">Overview of available API endpoints.</a>
+
+## Upgrading
+
+- <a href="docs/migration_v1_x.md">Migration from v1.x</a>  
 
 ## License
 BSD (Berkeley Software Distribution) License. Copyright (c) 2014-2018, Mollie B.V.

--- a/app/controllers/spree/api/v1/mollie_controller.rb
+++ b/app/controllers/spree/api/v1/mollie_controller.rb
@@ -4,9 +4,14 @@ module Spree
       class MollieController < BaseController
         def methods
           mollie = Spree::PaymentMethod.find_by_type 'Spree::Gateway::MollieGateway'
-          payment_methods = mollie.available_payment_methods
+          payment_methods = mollie.available_methods methods_params
 
           render json: payment_methods
+        end
+
+        private
+        def methods_params
+          params.permit(:amount => [:currency, :value])
         end
       end
     end

--- a/app/models/spree/gateway/mollie_gateway.rb
+++ b/app/models/spree/gateway/mollie_gateway.rb
@@ -149,7 +149,7 @@ module Spree
       end
     end
 
-    def available_methods(params)
+    def available_methods(params = nil)
       method_params = {
           api_key: get_preference(:api_key),
           include: 'issuers',

--- a/app/models/spree/gateway/mollie_gateway.rb
+++ b/app/models/spree/gateway/mollie_gateway.rb
@@ -72,9 +72,13 @@ module Spree
       order_number = gateway_options[:order_id]
       customer_id = gateway_options[:customer_id]
       amount = money_in_cents / 100.0
+      currency = gateway_options[:currency]
 
       order_params = {
-          amount: amount,
+          amount: {
+              value: amount.to_s,
+              currency: currency
+          },
           description: "Spree Order: #{order_number}",
           redirectUrl: spree_routes.mollie_validate_payment_mollie_url(
               order_number: order_number,

--- a/app/models/spree/gateway/mollie_gateway.rb
+++ b/app/models/spree/gateway/mollie_gateway.rb
@@ -47,7 +47,7 @@ module Spree
 
         source.status = mollie_payment.status
         source.payment_id = mollie_payment.id
-        source.payment_url = mollie_payment.payment_url
+        source.payment_url = mollie_payment.checkout_url
         source.save!
         ActiveMerchant::Billing::Response.new(true, 'Payment created')
       rescue Mollie::Exception => e

--- a/app/models/spree/gateway/mollie_gateway.rb
+++ b/app/models/spree/gateway/mollie_gateway.rb
@@ -124,14 +124,19 @@ module Spree
 
     # Create a new Mollie refund
     def credit(credit_cents, payment_id, options)
-      order_number = options[:originator].try(:payment).try(:order).try(:number)
+      order = options[:originator].try(:payment).try(:order)
+      order_number = order.try(:number)
+      order_currency = order.try(:currency)
       MollieLogger.debug("Starting refund for order #{order_number}")
 
       begin
         amount = credit_cents / 100.0
         Mollie::Payment::Refund.create(
             payment_id: payment_id,
-            amount: amount,
+            amount: {
+              value: sprintf("%.2f", amount.to_f),
+              currency: order_currency
+            },
             description: "Refund Spree Order ID: #{order_number}",
             api_key: get_preference(:api_key)
         )

--- a/app/models/spree/mollie_payment_source.rb
+++ b/app/models/spree/mollie_payment_source.rb
@@ -21,7 +21,7 @@ module Spree
           'iDEAL'
         when ::Mollie::Method::CREDITCARD then
           'Credit card'
-        when ::Mollie::Method::MISTERCASH then
+        when ::Mollie::Method::BANCONTACT then
           'Bancontact'
         when ::Mollie::Method::SOFORT then
           'SOFORT Banking'
@@ -37,12 +37,16 @@ module Spree
           'Belfius Pay Button'
         when ::Mollie::Method::PAYSAFECARD then
           'paysafecard'
-        when ::Mollie::Method::PODIUMCADEAUKAART then
-          'Podium Cadeaukaart'
         when ::Mollie::Method::GIFTCARD then
           'Giftcard'
         when ::Mollie::Method::INGHOMEPAY then
           'ING Home\'Pay'
+        when ::Mollie::Method::EPS then
+          'EPS'
+        when ::Mollie::Method::GIROPAY then
+          'Giropay'
+        when ::Mollie::Method::DIRECTDEBIT then
+          'SEPA Direct debit'
         else
           'Mollie'
       end

--- a/app/models/spree/payment/processing_decorator.rb
+++ b/app/models/spree/payment/processing_decorator.rb
@@ -18,7 +18,7 @@ Spree::Payment::Processing.module_eval do
   end
 
   def process_with_mollie
-    amount ||= money.money.cents
+    amount ||= money.money
     started_processing!
     response = payment_method.create_transaction(
         amount,

--- a/app/views/spree/checkout/payment/_molliegateway.html.erb
+++ b/app/views/spree/checkout/payment/_molliegateway.html.erb
@@ -1,11 +1,11 @@
 <ul class="list-group">
-  <% payment_method.available_payment_methods.each do |method| %>
+  <% payment_method.available_methods_for_order(@order).each do |method| %>
     <% prefix = "payment_source[#{payment_method.id}]" %>
     <div class="radio list-group-item">
 
       <label>
         <%= radio_button(prefix, :payment_method_name, method.id, class: 'js-mollie-payment-method') %>
-        <%= image_tag(method.image['normal']) %>
+        <%= image_tag(method.image['size1x']) %>
         <%= method.description %>
       </label>
 

--- a/docs/migration_v1_x.md
+++ b/docs/migration_v1_x.md
@@ -1,0 +1,11 @@
+# Migration from v1.x
+
+Version 2.x includes support for multicurrency payments and refunds. This feature has been introduced in the Mollie V2 API. Please refer to [Migrating from v1 to v2](https://docs.mollie.com/migrating-v1-to-v2) for a general overview of the switch to Mollie v2 API.
+
+## Retrieving payment methods using Spree API
+
+It's recommended to pass a `amount[currency]` and `amount[value]` URL params when fetching the available methods. This call will only return the available payment methods that are available for this currency and amount. 
+
+```bash
+curl "example.com/api/v1/mollie/methods?amount%5Bcurrency%5D=EUR&amount%5Bvalue%5D=10.00"
+```

--- a/spec/factories/mollie_gateway_factory.rb
+++ b/spec/factories/mollie_gateway_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     before(:create) do |gateway|
       gateway.preferences[:api_key] = ENV['MOLLIE_API_KEY']
-      gateway.preferences[:hostname] = 'https://example.com'
+      gateway.preferences[:hostname] = 'https://mollie.test'
     end
   end
 end

--- a/spec/factories/mollie_payment_source_factory.rb
+++ b/spec/factories/mollie_payment_source_factory.rb
@@ -1,5 +1,12 @@
 FactoryBot.define do
-  factory :mollie_payment_source, class: Spree::MolliePaymentSource do
+  # Creditcard payment
+  factory :mollie_cc_payment_source, class: Spree::MolliePaymentSource do
+    payment_method_name 'creditcard'
+    status 'open'
+  end
+
+  # iDEAL payment
+  factory :mollie_ideal_payment_source, class: Spree::MolliePaymentSource do
     payment_method_name 'ideal'
     issuer 'ideal_ABNANL2A'
     status 'open'

--- a/spec/factories/payment_factory_decorator.rb
+++ b/spec/factories/payment_factory_decorator.rb
@@ -6,12 +6,4 @@ FactoryBot.define do
     order
     state 'checkout'
   end
-
-  factory :mollie_multicurrency_payment, class: Spree::Payment do
-    amount 12.73
-    association(:payment_method, factory: :mollie_gateway)
-    association(:source, factory: :mollie_ideal_payment_source)
-    order
-    state 'checkout'
-  end
 end

--- a/spec/factories/payment_factory_decorator.rb
+++ b/spec/factories/payment_factory_decorator.rb
@@ -2,7 +2,15 @@ FactoryBot.define do
   factory :mollie_payment, class: Spree::Payment do
     amount 12.73
     association(:payment_method, factory: :mollie_gateway)
-    association(:source, factory: :mollie_payment_source)
+    association(:source, factory: :mollie_cc_payment_source)
+    order
+    state 'checkout'
+  end
+
+  factory :mollie_multicurrency_payment, class: Spree::Payment do
+    amount 12.73
+    association(:payment_method, factory: :mollie_gateway)
+    association(:source, factory: :mollie_ideal_payment_source)
     order
     state 'checkout'
   end

--- a/spec/models/spree/gateway/mollie_gateway_spec.rb
+++ b/spec/models/spree/gateway/mollie_gateway_spec.rb
@@ -47,12 +47,6 @@ RSpec.describe Spree::Gateway::MollieGateway, type: :model do
       expect(payment.state).to eq 'failed'
     end
 
-    it 'should set payment state to void for refunded Mollie payment' do
-      mollie_api_payment.status = 'refunded'
-      gateway.update_by_mollie_status!(mollie_api_payment, payment)
-      expect(payment.state).to eq 'void'
-    end
-
     context 'payment method' do
       it 'should have a list of payment methods' do
         expect(gateway.available_methods.first).to be_an_instance_of(Mollie::Method)

--- a/spec/models/spree/gateway/mollie_gateway_spec.rb
+++ b/spec/models/spree/gateway/mollie_gateway_spec.rb
@@ -62,5 +62,9 @@ RSpec.describe Spree::Gateway::MollieGateway, type: :model do
         expect(gateway.available_payment_methods.first.issuers.first).to include('id' => 'ideal_ABNANL2A', 'method' => 'ideal')
       end
     end
+
+    context 'multi-currency' do
+      it 'should '
+    end
   end
 end

--- a/spec/models/spree/gateway/mollie_gateway_spec.rb
+++ b/spec/models/spree/gateway/mollie_gateway_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Spree::Gateway::MollieGateway, type: :model do
     end
 
     it 'should set payment state to failed for cancelled Mollie payment' do
-      mollie_api_payment.status = 'cancelled'
+      mollie_api_payment.status = 'canceled'
       gateway.update_by_mollie_status!(mollie_api_payment, payment)
       expect(payment.state).to eq 'failed'
     end
@@ -55,11 +55,11 @@ RSpec.describe Spree::Gateway::MollieGateway, type: :model do
 
     context 'payment method' do
       it 'should have a list of payment methods' do
-        expect(gateway.available_payment_methods.first).to be_an_instance_of(Mollie::Method)
+        expect(gateway.available_methods.first).to be_an_instance_of(Mollie::Method)
       end
 
       it 'should have nested issuers on payment methods' do
-        expect(gateway.available_payment_methods.first.issuers.first).to include('id' => 'ideal_ABNANL2A', 'method' => 'ideal')
+        expect(gateway.available_methods.first.issuers.first).to include('name' => 'ABN AMRO', 'image' => {'size1x' => 'https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/ABNANL2A.png', 'size2x' => 'https://www.mollie.com/images/checkout/v2/ideal-issuer-icons/ABNANL2A.png'}, 'resource' => 'issuer')
       end
     end
   end

--- a/spec/models/spree/gateway/mollie_gateway_spec.rb
+++ b/spec/models/spree/gateway/mollie_gateway_spec.rb
@@ -62,9 +62,5 @@ RSpec.describe Spree::Gateway::MollieGateway, type: :model do
         expect(gateway.available_payment_methods.first.issuers.first).to include('id' => 'ideal_ABNANL2A', 'method' => 'ideal')
       end
     end
-
-    context 'multi-currency' do
-      it 'should '
-    end
   end
 end

--- a/spree_mollie_gateway.gemspec
+++ b/spree_mollie_gateway.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coffee-rails'
   spec.add_development_dependency 'database_cleaner'
 
-  spec.add_runtime_dependency 'mollie-api-ruby', '~> 4.0.0-alpha.1'
+  spec.add_runtime_dependency 'mollie-api-ruby', '~> 4.0.0'
 end

--- a/spree_mollie_gateway.gemspec
+++ b/spree_mollie_gateway.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coffee-rails'
   spec.add_development_dependency 'database_cleaner'
 
-  spec.add_runtime_dependency 'mollie-api-ruby', '~> 3.1', '>= 3.1.4'
+  spec.add_runtime_dependency 'mollie-api-ruby'
 end

--- a/spree_mollie_gateway.gemspec
+++ b/spree_mollie_gateway.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coffee-rails'
   spec.add_development_dependency 'database_cleaner'
 
-  spec.add_runtime_dependency 'mollie-api-ruby'
+  spec.add_runtime_dependency 'mollie-api-ruby', '~> 4.0.0-alpha.1'
 end


### PR DESCRIPTION
Fixes #8.

- [x] Set current currency and amount.
- [x] Get available payment methods based on current currency + amount
- [x] Update payment states (`cancelled` => `canceled`).
- [x] Pass amount object (including currency) when creating a new refund.
- [x] Update method constants.
- [x] Update Spree API endpoint (methods)
- [x] Update tests.