### PR TITLE
Check if Mollie gateway is present

### DIFF
--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -5,6 +5,7 @@ Spree.user_class.class_eval do
     # Don't create Mollie customers if spree_auth_devise is not installed.
     return unless defined? Spree::User
     mollie_gateway = Spree::PaymentMethod.find_by_type 'Spree::Gateway::MollieGateway'
+    return unless mollie_gateway.present?
     mollie_customer = mollie_gateway.create_customer(self)
     update mollie_customer_id: mollie_customer.id
   end


### PR DESCRIPTION
Don't create a Mollie customer when saving a new `Spree::User` if Mollie isn't added as a payment method (but the gem is installed).

Fixes #11 