### PR TITLE
support for other payment methods in payment decorator

### DIFF
--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,5 +1,12 @@
 Spree::Payment.class_eval do
-  delegate :transaction_id, to: :source
+
+  def transaction_id
+    if payment_method.is_a? Spree::Gateway::MollieGateway
+      source.transaction_id
+    else
+      response_code
+    end
+  end
 
   def build_source
     return unless new_record?


### PR DESCRIPTION
Hi, I was getting a Module::DelegationError in Spree::Admin::Payments#index, when using payment methods different from Mollie. This should resolve it.