### PR TITLE
Release 2.0.0-alpha.1

### DIFF
--- a/lib/spree_mollie_gateway/version.rb
+++ b/lib/spree_mollie_gateway/version.rb
@@ -1,3 +1,3 @@
 module SpreeMollieGateway
-  VERSION = '1.0.7'
+  VERSION = '2.0.0-alpha.1'
 end


### PR DESCRIPTION
- Only set method if param is sent via API.
- Use `try` to access properties on objects that might not be set.
- Bump version to `2.0.0-alpha.1`