### PR TITLE
Don't use localized money format when submitting amounts

### DIFF
--- a/app/models/spree/gateway/mollie_gateway.rb
+++ b/app/models/spree/gateway/mollie_gateway.rb
@@ -88,7 +88,7 @@ module Spree
 
       order_params = {
           amount: {
-              value: money.to_s,
+              value: format_money(money),
               currency: currency
           },
           description: "Spree Order: #{order_number}",
@@ -153,7 +153,7 @@ module Spree
         Mollie::Payment::Refund.create(
             payment_id: payment_id,
             amount: {
-                value: order.display_total.money.to_s,
+                value: format_money(order.display_total.money),
                 currency: order_currency
             },
             description: "Refund Spree Order ID: #{order_number}",
@@ -180,11 +180,15 @@ module Spree
       ::Mollie::Method.all(method_params)
     end
 
+    def format_money(money)
+      money.format(symbol: nil, thousands_separator: nil, decimal_mark: '.')
+    end
+
     def available_methods_for_order(order)
       params = {
           amount: {
               currency: order.currency,
-              value: order.display_total.money.to_s
+              value: format_money(order.display_total.money)
           }
       }
       available_methods(params)


### PR DESCRIPTION
We shouldn't commit localized strings like 100,00 to the API

I'm not sure if hardcoding separator and mark is the best way to go