### PR TITLE
reset order to payment state on failed payment

### DIFF
--- a/app/models/spree/gateway/mollie_gateway.rb
+++ b/app/models/spree/gateway/mollie_gateway.rb
@@ -214,8 +214,10 @@ module Spree
         payment.order.update_attributes(:state => 'complete', :completed_at => Time.now)
       when 'canceled', 'expired', 'failed'
         payment.failure! unless payment.failed?
+        payment.order.update_attributes(:state => 'payment', :completed_at => nil)
       else
         MollieLogger.debug('Unhandled Mollie payment state received. Therefore we did not update the payment state.')
+        payment.order.update_attributes(state: 'payment', completed_at: nil)
       end
 
       payment.source.update(status: payment.state)

--- a/app/views/spree/api/v1/orders/complete.v1.rabl
+++ b/app/views/spree/api/v1/orders/complete.v1.rabl
@@ -1,0 +1,7 @@
+child :available_payment_methods => :payment_methods do
+  attributes :id, :name, :method_type
+
+  node :gateways do |payment_method|
+    payment_method.gateways(order: @order)
+  end
+end


### PR DESCRIPTION
Aftr the payment failed or an unidentified state comes in the order should revert to the payment state so the user can pick another payment option.

Also when a user goes back in their browser physically the order has been completed. In order to allow a SPA or other API facing system to still show payment options without the API provider being notified of this 'back' action the payment options are exposed on complete orders as well. 