### PR TITLE
only finalize shipments when order is paid

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -8,7 +8,7 @@ Spree::Order.class_eval do
     updater.update_payment_state
     shipments.each do |shipment|
       shipment.update!(self)
-      shipment.finalize!
+      shipment.finalize! if paid?
     end
 
     updater.update_shipment_state


### PR DESCRIPTION
By design the plugin completes the order when a payment method is selected. De facto the spree system finalises the order when the order transitions to complete. Part of this finalisation is finalising shipments. This means stock is deducted.

Upon registering a complete payment, the mollie gem finalises the order again which results in another stock reduction.

This PR prevents stock reduction until the order has been paid