### PR TITLE
Payment refunds should not update order.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-- 2.2.7
+- 2.3.0
 before_install: gem install bundler -v 1.16.1
 deploy:
   provider: rubygems

--- a/app/models/spree/gateway/mollie_gateway.rb
+++ b/app/models/spree/gateway/mollie_gateway.rb
@@ -237,15 +237,14 @@ module Spree
 
         if payment.completed?
           MollieLogger.debug('Payment is already completed. Not updating the payment status within Spree.')
+          return
         end
 
         # If order is already paid for, don't mark it as complete again.
-        unless payment.completed?
-          payment.complete!
-          payment.order.finalize!
-          payment.order.update_attributes(:state => 'complete', :completed_at => Time.now)
-          MollieLogger.debug('Payment is paid and will transition to completed. Order will be finalized.')
-        end
+        payment.complete!
+        payment.order.finalize!
+        payment.order.update_attributes(:state => 'complete', :completed_at => Time.now)
+        MollieLogger.debug('Payment is paid and will transition to completed. Order will be finalized.')
       when 'canceled', 'expired', 'failed'
         payment.failure! unless payment.failed?
         payment.order.update_attributes(:state => 'payment', :completed_at => nil)

--- a/app/models/spree/gateway/mollie_gateway.rb
+++ b/app/models/spree/gateway/mollie_gateway.rb
@@ -183,7 +183,7 @@ module Spree
           ActiveMerchant::Billing::Response.new(true, 'Mollie payment has not been cancelled because it is not cancelable')
         end
       rescue Mollie::Exception => e
-        MollieLogger.debug("Payment #{transaction_id} could not be canceled #{transaction_id}: #{e.message}")
+        MollieLogger.debug("Payment #{transaction_id} could not be canceled: #{e.message}")
         ActiveMerchant::Billing::Response.new(false, 'Payment cancellation unsuccessful')
       end
     end

--- a/app/models/spree/gateway/mollie_gateway.rb
+++ b/app/models/spree/gateway/mollie_gateway.rb
@@ -75,7 +75,7 @@ module Spree
       customer = Mollie::Customer.create(
           email: user.email,
           api_key: get_preference(:api_key),
-          )
+      )
       MollieLogger.debug("Created a Mollie Customer for Spree user with ID #{customer.id}")
       customer
     end
@@ -168,15 +168,22 @@ module Spree
     end
 
     def cancel(transaction_id)
+      MollieLogger.debug("Starting cancelation for #{transaction_id}")
+
       begin
         mollie_payment = ::Mollie::Payment.get(
             transaction_id,
             api_key: get_preference(:api_key)
         )
-        mollie_payment.delete(transaction_id) if mollie_payment.cancelable?
-        ActiveMerchant::Billing::Response.new(true, 'Payment canceled successful')
+        if mollie_payment.cancelable?
+          mollie_payment.delete(transaction_id)
+          ActiveMerchant::Billing::Response.new(true, 'Mollie payment has been cancelled')
+        else
+          MollieLogger.debug("Molie payment #{transaction_id} is not cancelable. Skipping any further updates.")
+          ActiveMerchant::Billing::Response.new(true, 'Mollie payment has not been cancelled because it is not cancelable')
+        end
       rescue Mollie::Exception => e
-        MollieLogger.debug("Payment could not be canceled #{transaction_id}: #{e.message}")
+        MollieLogger.debug("Payment #{transaction_id} could not be canceled #{transaction_id}: #{e.message}")
         ActiveMerchant::Billing::Response.new(false, 'Payment cancellation unsuccessful')
       end
     end
@@ -215,23 +222,36 @@ module Spree
           api_key: get_preference(:api_key)
       )
 
-      MollieLogger.debug("Updating order state for payment. Payment has state #{mollie_payment.status}")
-
+      MollieLogger.debug("Checking Mollie payment status. Mollie payment has status #{mollie_payment.status}")
       update_by_mollie_status!(mollie_payment, payment)
     end
 
     def update_by_mollie_status!(mollie_payment, payment)
       case mollie_payment.status
-        when 'paid'
-          payment.complete! unless payment.completed?
+      when 'paid'
+        # If Mollie payment is already paid and refunded amount is more than 0, don't update payment
+        if mollie_payment.paid? && mollie_payment.amount_refunded.value > 0
+          MollieLogger.debug('Payment is refunded. Not updating the payment status within Spree.')
+          return
+        end
+
+        if payment.completed?
+          MollieLogger.debug('Payment is already completed. Not updating the payment status within Spree.')
+        end
+
+        # If order is already paid for, don't mark it as complete again.
+        unless payment.completed?
+          payment.complete!
           payment.order.finalize!
           payment.order.update_attributes(:state => 'complete', :completed_at => Time.now)
-        when 'canceled', 'expired', 'failed'
-          payment.failure! unless payment.failed?
-          payment.order.update_attributes(:state => 'payment', :completed_at => nil)
-        else
-          MollieLogger.debug('Unhandled Mollie payment state received. Therefore we did not update the payment state.')
-          payment.order.update_attributes(state: 'payment', completed_at: nil)
+          MollieLogger.debug('Payment is paid and will transition to completed. Order will be finalized.')
+        end
+      when 'canceled', 'expired', 'failed'
+        payment.failure! unless payment.failed?
+        payment.order.update_attributes(:state => 'payment', :completed_at => nil)
+      else
+        MollieLogger.debug('Unhandled Mollie payment state received. Therefore we did not update the payment state.')
+        payment.order.update_attributes(state: 'payment', completed_at: nil)
       end
 
       payment.source.update(status: payment.state)

--- a/spec/factories/mollie_api_payment_factory.rb
+++ b/spec/factories/mollie_api_payment_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :mollie_api_payment, class: Mollie::Payment do
     skip_create
-    initialize_with { new([]) }
+    initialize_with {new([])}
   end
 end

--- a/spec/factories/mollie_gateway_factory.rb
+++ b/spec/factories/mollie_gateway_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     before(:create) do |gateway|
       gateway.preferences[:api_key] = ENV['MOLLIE_API_KEY']
-      gateway.preferences[:hostname] = 'https://mollie.test'
+      gateway.preferences[:hostname] = 'https://mollie.com'
     end
   end
 end

--- a/spec/factories/mollie_payment_source_factory.rb
+++ b/spec/factories/mollie_payment_source_factory.rb
@@ -1,14 +1,7 @@
 FactoryBot.define do
-  # Creditcard payment
-  factory :mollie_cc_payment_source, class: Spree::MolliePaymentSource do
+  # Credit card payment
+  factory :mollie_payment_source, class: Spree::MolliePaymentSource do
     payment_method_name 'creditcard'
-    status 'open'
-  end
-
-  # iDEAL payment
-  factory :mollie_ideal_payment_source, class: Spree::MolliePaymentSource do
-    payment_method_name 'ideal'
-    issuer 'ideal_ABNANL2A'
     status 'open'
   end
 end

--- a/spec/factories/payment_factory_decorator.rb
+++ b/spec/factories/payment_factory_decorator.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :mollie_payment, class: Spree::Payment do
     amount 12.73
     association(:payment_method, factory: :mollie_gateway)
-    association(:source, factory: :mollie_cc_payment_source)
+    association(:source, factory: :mollie_payment_source)
     order
     state 'checkout'
   end

--- a/spec/models/spree/gateway/mollie_gateway_spec.rb
+++ b/spec/models/spree/gateway/mollie_gateway_spec.rb
@@ -18,12 +18,20 @@ RSpec.describe Spree::Gateway::MollieGateway, type: :model do
     context 'with paid Mollie payment' do
       it 'should set payment state to paid for paid Mollie payment' do
         mollie_api_payment.status = 'paid'
+        mollie_api_payment.amount_refunded = {
+            currency: 'EUR',
+            value: '0.00'
+        }
         gateway.update_by_mollie_status!(mollie_api_payment, payment)
         expect(payment.state).to eq 'completed'
       end
 
       it 'should set order state to complete for paid Mollie payment' do
         mollie_api_payment.status = 'paid'
+        mollie_api_payment.amount_refunded = {
+            currency: 'EUR',
+            value: '0.00'
+        }
         gateway.update_by_mollie_status!(mollie_api_payment, payment)
         expect(payment.order.state).to eq 'complete'
       end
@@ -68,6 +76,23 @@ RSpec.describe Spree::Gateway::MollieGateway, type: :model do
         mollie_api_payment.status = 'failed'
         gateway.update_by_mollie_status!(mollie_api_payment, payment)
         expect(order.state).to eq 'payment'
+      end
+    end
+
+    context 'with refunded Mollie payment' do
+      it 'should not update payment state' do
+        payment.state = 'paid'
+        order.state = 'complete'
+        order.completed_at = '2018-10-22 08:42:30'
+        mollie_api_payment.status = 'paid'
+        mollie_api_payment.amount_refunded = {
+            currency: 'EUR',
+            value: '15.00'
+        }
+        gateway.update_by_mollie_status!(mollie_api_payment, payment)
+        expect(payment.state).to eq 'paid'
+        expect(order.state).to eq 'complete'
+        expect(order.completed_at).to eq '2018-10-22 08:42:30'
       end
     end
 


### PR DESCRIPTION
We received a bug report last week about order confirmation emails being delivered twice when a merchant refunds a payment within Mollie.

**The issue**
At this moment, every time the Mollie webhook is called, the method `update_by_mollie_status!` is called. This will check what the current status of the payment is, and update the status of the `Spree::Order` / `Spree::Payment` accordingly. If the status of the Mollie payment is paid, we'll finalize  the order and send the order confirmation.

This worked fine when we were still using the Mollie v1 API. However, since we're now using the v2 API, `refunded` is not a separate payment status anymore. Therefore, the order will be finalized again for every webhook call that happens after a payment refund.

**Proposed solution**
To fix this, we should only finalize the order (which takes care of sending the order confirmation email) and set the `completed_at` to the current date + time if the order has not been paid for yet but the Mollie payment is paid. I added a test for this as well.