### PR TITLE
Allow Spree >= 3.1.0 as a runtime dependency

### DIFF
--- a/spree_mollie_gateway.gemspec
+++ b/spree_mollie_gateway.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spree_version = '~> 3.6.3'
+  spree_version = '>= 3.1.0'
   spec.add_dependency 'spree_core', spree_version
   spec.add_dependency 'spree_backend', spree_version
   spec.add_dependency 'spree_frontend', spree_version


### PR DESCRIPTION
We should be less strict in requiring Spree as a runtime dependency. Allow Spree >= 3.1.0 for:

- `spree_core`
- `spree_backend`
- `spree_frontend`