### PR TITLE
Persist shipping discounts when creating a Mollie order

### DIFF
--- a/app/models/spree/mollie/order_serializer.rb
+++ b/app/models/spree/mollie/order_serializer.rb
@@ -83,9 +83,16 @@ module Spree
         @order.line_items.each do |line|
           order_lines << serialize_line_item(line)
         end
-        order_lines << serialize_discounts if @order.has_order_adjustments?
+
+        if @order.has_order_adjustments?
+          order_lines << serialize_discounts
+        end
+
         order_lines << serialize_shipping_costs
-        order_lines << serialize_shipping_discounts if @order.shipping_discount > 0
+
+        if @order.shipping_discount.positive?
+          order_lines << serialize_shipping_discounts
+        end
 
         order_lines
       end

--- a/app/models/spree/mollie/order_serializer.rb
+++ b/app/models/spree/mollie/order_serializer.rb
@@ -84,9 +84,7 @@ module Spree
           order_lines << serialize_line_item(line)
         end
 
-        if @order.has_order_adjustments?
-          order_lines << serialize_discounts
-        end
+        order_lines << serialize_discounts if @order.has_order_adjustments?
 
         order_lines << serialize_shipping_costs
 

--- a/app/models/spree/mollie/order_serializer.rb
+++ b/app/models/spree/mollie/order_serializer.rb
@@ -85,6 +85,9 @@ module Spree
         end
         order_lines << serialize_discounts if @order.has_order_adjustments?
         order_lines << serialize_shipping_costs
+        order_lines << serialize_shipping_discounts if @order.shipping_discount > 0
+
+        order_lines
       end
 
       def serialize_address(address)
@@ -133,6 +136,27 @@ module Spree
           totalAmount: {
             currency: @order.currency,
             value: format_money(@order.display_order_adjustment_total.money)
+          },
+          vatAmount: {
+            currency: @order.currency,
+            value: '0.00'
+          },
+          vatRate: '0'
+        }
+      end
+
+      def serialize_shipping_discounts
+        {
+          type: 'discount',
+          name: 'Shipping discount',
+          quantity: 1,
+          unitPrice: {
+            currency: @order.currency,
+            value: format_money(-@order.display_shipping_discount.money)
+          },
+          totalAmount: {
+            currency: @order.currency,
+            value: format_money(-@order.display_shipping_discount.money)
           },
           vatAmount: {
             currency: @order.currency,

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,5 +1,5 @@
 Spree::Order.class_eval do
-  money_methods :order_adjustment_total
+  money_methods :order_adjustment_total, :shipping_discount
 
   # Make sure the order confirmation is delivered when the order has been paid for.
   def finalize!

--- a/spec/models/spree/mollie/order_serializer_spec.rb
+++ b/spec/models/spree/mollie/order_serializer_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
   context 'serialization' do
     let(:serialized_order) do
       serializer = Spree::Mollie::OrderSerializer.new(
-          order_total,
-          payment_source,
-          payment.gateway_options,
-          gateway_preferences
+        order_total,
+        payment_source,
+        payment.gateway_options,
+        gateway_preferences
       )
       serializer.serialize
     end
@@ -132,10 +132,10 @@ RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
 
       let(:serialized_order) do
         serializer = Spree::Mollie::OrderSerializer.new(
-            order_total,
-            payment_source,
-            payment.gateway_options,
-            gateway_preferences
+          order_total,
+          payment_source,
+          payment.gateway_options,
+          gateway_preferences
         )
         serializer.serialize
       end
@@ -179,10 +179,10 @@ RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
 
       let(:serialized_order) do
         serializer = Spree::Mollie::OrderSerializer.new(
-            order_total,
-            payment_source,
-            payment.gateway_options,
-            gateway_preferences
+          order_total,
+          payment_source,
+          payment.gateway_options,
+          gateway_preferences
         )
         serializer.serialize
       end

--- a/spec/models/spree/mollie/order_serializer_spec.rb
+++ b/spec/models/spree/mollie/order_serializer_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
   let(:order) { create :order_with_line_items, line_items_count: 1 }
   let(:gateway) { create(:mollie_gateway, auto_capture: true) }
-  let(:payment) { create(:mollie_payment, payment_method: gateway) }
+  let(:payment) { create(:mollie_payment, payment_method: gateway, order: order) }
+  let(:calculator) { Calculator::FlatRate.new(preferred_amount: 10) }
   let(:payment_source) { payment.payment_source }
   let(:line_item) { order.line_items.first }
   let(:line_item_promo) do
@@ -39,7 +40,10 @@ RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
   end
 
   context 'serialization' do
-    let(:serialized_order) { Spree::Mollie::OrderSerializer.serialize(order_total, payment_source, payment.gateway_options, gateway_preferences) }
+    let(:serialized_order) do
+      serializer = Spree::Mollie::OrderSerializer.new(order_total, payment_source, payment.gateway_options, gateway_preferences)
+      serializer.serialize
+    end
 
     it 'contains amount' do
       expect(serialized_order[:amount][:currency]).to eq 'USD'
@@ -73,51 +77,121 @@ RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
       expect(serialized_order[:method]).to eq 'creditcard'
     end
 
-    context 'billing_address' do
-      let(:billing_address) { serialized_order[:billingAddress] }
+    context 'billing address' do
+      subject { serialized_order[:billingAddress] }
 
       it 'has a billing address' do
-        expect(billing_address).to be_kind_of Hash
+        expect(subject).to be_kind_of Hash
       end
 
       it 'has streetAndNumber' do
-        expect(billing_address[:streetAndNumber]).to eq '10 Lovely Street'
+        expect(subject[:streetAndNumber]).to eq '10 Lovely Street'
       end
 
       it 'has city' do
-        expect(billing_address[:city]).to eq 'Herndon'
+        expect(subject[:city]).to eq 'Herndon'
       end
 
       it 'has postalCode' do
-        expect(billing_address[:postalCode]).to eq '35005'
+        expect(subject[:postalCode]).to eq '35005'
       end
 
       it 'has country' do
-        expect(billing_address[:country]).to eq 'US'
+        expect(subject[:country]).to eq 'US'
       end
 
       it 'has region' do
-        expect(billing_address[:region]).not_to be_empty
+        expect(subject[:region]).not_to be_empty
       end
 
       it 'has givenName' do
-        expect(billing_address[:givenName]).to eq 'John'
+        expect(subject[:givenName]).to eq 'John'
       end
 
       it 'has familyname' do
-        expect(billing_address[:familyName]).to eq 'Doe'
+        expect(subject[:familyName]).to eq 'Doe'
       end
 
       it 'has email' do
-        expect(billing_address[:email]).not_to be_empty
+        expect(subject[:email]).not_to be_empty
       end
     end
 
-    context 'shipping_fee' do
-      let(:shipping_fee) { serialized_order[:lines].first }
+    context 'shipping fee' do
+      subject { serialized_order[:lines].detect { |line| line[:type] === 'shipping_fee' } }
+
+      let!(:set_ship_total) do
+        order.ship_total = 10
+        order.save!
+      end
+
+      let(:serialized_order) do
+        serializer = Spree::Mollie::OrderSerializer.new(order_total, payment_source, payment.gateway_options, gateway_preferences)
+        serializer.serialize
+      end
 
       it 'has a quantity of 1' do
-        expect(shipping_fee[:quantity]).to eq(1)
+        expect(subject[:quantity]).to eq(1)
+      end
+
+      it 'is present' do
+        expect(subject).not_to be_empty
+      end
+
+      it 'has unitPrice' do
+        expect(subject[:unitPrice][:value]).to eq('10.00')
+        expect(subject[:unitPrice][:currency]).to eq('USD')
+      end
+
+      it 'has no discountAmount' do
+        expect(subject[:discountAmount]).to be_nil
+      end
+
+      it 'has totalAmount' do
+        expect(subject[:totalAmount][:value]).to eq('10.00')
+        expect(subject[:totalAmount][:currency]).to eq('USD')
+      end
+    end
+
+    context 'shipping discount' do
+      # Set up free shipping promotion
+      subject { serialized_order[:lines].detect { |line| line[:name] === 'Shipping discount' } }
+
+      let(:promotion) { create(:promotion) }
+      let(:action) { Spree::Promotion::Actions::FreeShipping.create }
+      let(:payload) { { order: order } }
+
+      before do
+        order.shipments << create(:shipment)
+        promotion.promotion_actions << action
+        action.perform(payload)
+      end
+
+      let(:serialized_order) do
+        serializer = Spree::Mollie::OrderSerializer.new(order_total, payment_source, payment.gateway_options, gateway_preferences)
+        serializer.serialize
+      end
+
+      it 'has been applied' do
+        expect(order.shipment_adjustments.count).to eq(1)
+      end
+
+      it 'is present' do
+        expect(subject).not_to be_empty
+      end
+
+      it 'has unitPrice' do
+        expect(subject[:unitPrice][:value]).to eq('-100.00')
+        expect(subject[:unitPrice][:currency]).to eq('USD')
+      end
+
+      it 'has no discountAmount' do
+        expect(subject[:discountAmount]).to be_nil
+      end
+
+      it 'has totalAmount' do
+        expect(subject[:totalAmount][:value]).to eq('-100.00')
+        expect(subject[:totalAmount][:currency]).to eq('USD')
       end
     end
   end

--- a/spec/models/spree/mollie/order_serializer_spec.rb
+++ b/spec/models/spree/mollie/order_serializer_spec.rb
@@ -41,7 +41,12 @@ RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
 
   context 'serialization' do
     let(:serialized_order) do
-      serializer = Spree::Mollie::OrderSerializer.new(order_total, payment_source, payment.gateway_options, gateway_preferences)
+      serializer = Spree::Mollie::OrderSerializer.new(
+          order_total,
+          payment_source,
+          payment.gateway_options,
+          gateway_preferences
+      )
       serializer.serialize
     end
 
@@ -118,7 +123,7 @@ RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
     end
 
     context 'shipping fee' do
-      subject { serialized_order[:lines].detect { |line| line[:type] === 'shipping_fee' } }
+      subject { serialized_order[:lines].detect { |line| line[:type] == 'shipping_fee' } }
 
       let!(:set_ship_total) do
         order.ship_total = 10
@@ -126,7 +131,12 @@ RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
       end
 
       let(:serialized_order) do
-        serializer = Spree::Mollie::OrderSerializer.new(order_total, payment_source, payment.gateway_options, gateway_preferences)
+        serializer = Spree::Mollie::OrderSerializer.new(
+            order_total,
+            payment_source,
+            payment.gateway_options,
+            gateway_preferences
+        )
         serializer.serialize
       end
 
@@ -155,7 +165,7 @@ RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
 
     context 'shipping discount' do
       # Set up free shipping promotion
-      subject { serialized_order[:lines].detect { |line| line[:name] === 'Shipping discount' } }
+      subject { serialized_order[:lines].detect { |line| line[:name] == 'Shipping discount' } }
 
       let(:promotion) { create(:promotion) }
       let(:action) { Spree::Promotion::Actions::FreeShipping.create }
@@ -168,7 +178,12 @@ RSpec.describe Spree::Mollie::OrderSerializer, type: :model do
       end
 
       let(:serialized_order) do
-        serializer = Spree::Mollie::OrderSerializer.new(order_total, payment_source, payment.gateway_options, gateway_preferences)
+        serializer = Spree::Mollie::OrderSerializer.new(
+            order_total,
+            payment_source,
+            payment.gateway_options,
+            gateway_preferences
+        )
         serializer.serialize
       end
 


### PR DESCRIPTION
This PR fixes the following issue:
- When an order has a promotion applied that will set the shipping costs to 0, the order cannot be created at Mollie. This is because the order amounts don't match.

We need to check if an order has shipping discounts and send them to Mollie when we create a `Mollie::Order`.