### PR TITLE
Show "authorized" status in spree admin

### DIFF
--- a/app/models/spree/mollie/payment_state_updater.rb
+++ b/app/models/spree/mollie/payment_state_updater.rb
@@ -23,6 +23,7 @@ module Spree
           @spree_payment.source.update(status: @spree_payment.state)
         when 'shipping'
           transition_to_shipping!
+          @spree_payment.source.update(status: @spree_payment.state)
         else
           MollieLogger.debug("Unhandled Mollie payment state received: #{@mollie_order.status}. Therefore we did not update the payment state.")
           @spree_payment.order.update_attributes(state: 'payment', completed_at: nil)

--- a/app/models/spree/mollie/payment_state_updater.rb
+++ b/app/models/spree/mollie/payment_state_updater.rb
@@ -14,18 +14,19 @@ module Spree
         case @mollie_order.status
         when 'paid', 'completed'
           transition_to_paid!
+          @spree_payment.source.update(status: @spree_payment.state)
         when 'canceled', 'expired'
           transition_to_failed!
+          @spree_payment.source.update(status: @spree_payment.state)
         when 'authorized'
           transition_to_authorized!
+          @spree_payment.source.update(status: @spree_payment.state)
         when 'shipping'
           transition_to_shipping!
         else
           MollieLogger.debug("Unhandled Mollie payment state received: #{@mollie_order.status}. Therefore we did not update the payment state.")
           @spree_payment.order.update_attributes(state: 'payment', completed_at: nil)
         end
-
-        @spree_payment.source.update(status: @spree_payment.state)
       end
 
       private

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -28,4 +28,12 @@ Spree::Payment.class_eval do
       false
     end
   end
+
+  def after_pay_method?
+    if source.is_a? Spree::MolliePaymentSource
+      return source.payment_method_name == ::Mollie::Method::KLARNAPAYLATER || source.payment_method_name == ::Mollie::Method::KLARNASLICEIT
+    else
+      false
+    end
+  end
 end

--- a/app/views/spree/admin/orders/index.html.erb
+++ b/app/views/spree/admin/orders/index.html.erb
@@ -1,0 +1,236 @@
+<% content_for :page_title do %>
+  <%= plural_resource_name(Spree::Order) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <%= button_link_to Spree.t(:new_order), new_admin_order_url, class: "btn-success", icon: 'add', id: 'admin_new_order' %>
+<% end if can? :create, Spree::Order %>
+
+<% content_for :table_filter do %>
+  <div data-hook="admin_orders_index_search">
+
+    <%= search_form_for [:admin, @search] do |f| %>
+      <div class="row">
+        <div class="date-range-filter col-xs-12 col-md-8">
+          <div class="form-group">
+            <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
+            <div class="row no-padding-bottom">
+              <div class="col-xs-12 col-md-6">
+                <div class="input-group">
+                  <%= f.text_field :created_at_gt, class: 'datepicker datepicker-from form-control', value: params[:q][:created_at_gt], placeholder: Spree.t(:start) %>
+                  <span class="input-group-addon">
+                    <i class="icon icon-calendar"></i>
+                  </span>
+                </div>
+
+              </div>
+              <div class="col-xs-12 col-md-6">
+                <div class="input-group">
+                  <%= f.text_field :created_at_lt, class: 'datepicker datepicker-to form-control', value: params[:q][:created_at_lt], placeholder: Spree.t(:stop) %>
+                  <span class="input-group-addon">
+                    <i class="icon icon-calendar"></i>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_number_cont, Spree.t(:order_number, number: '') %>
+            <%= f.text_field :number_cont, class: 'form-control js-quick-search-target' %>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="row">
+
+        <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_state_eq, Spree.t(:status) %>
+            <%= f.select :state_eq, Spree::Order.state_machines[:state].states.map {|s| [Spree.t("order_state.#{s.name}"), s.value]}, { include_blank: true }, class: 'select2 js-filterable' %>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
+            <%= f.select :payment_state_eq, Spree::Order::PAYMENT_STATES.map {|s| [Spree.t("payment_states.#{s}"), s]}, { include_blank: true }, class: 'select2 js-filterable' %>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_shipment_state_eq, Spree.t(:shipment_state) %>
+            <%= f.select :shipment_state_eq, Spree::Order::SHIPMENT_STATES.map {|s| [Spree.t("shipment_states.#{s}"), s]}, { include_blank: true }, class: 'select2 js-filterable' %>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="row">
+
+        <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_bill_address_firstname_start, Spree.t(:first_name_begins_with) %>
+            <%= f.text_field :bill_address_firstname_start, class: 'form-control' %>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_bill_address_lastname_start, Spree.t(:last_name_begins_with) %>
+            <%= f.text_field :bill_address_lastname_start, class: 'form-control' %>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_email_cont, Spree.t(:email) %>
+            <%= f.text_field :email_cont, class: 'form-control js-filterable' %>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="row">
+
+        <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_line_items_variant_sku_eq, Spree.t(:sku) %>
+            <%= f.text_field :line_items_variant_sku_eq, class: 'form-control' %>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_promotions_id_in, Spree.t(:promotion) %>
+            <%= f.select :promotions_id_in, Spree::Promotion.applied.pluck(:name, :id), { include_blank: true }, class: 'select2' %>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4">
+          <div class="form-group">
+            <%= label_tag :q_store_id_in, Spree.t(:store) %>
+            <%= f.select :store_id_in, Spree::Store.order("#{Spree::Store.table_name}.name").pluck(:name, :id), { include_blank: true }, class: 'select2' %>
+          </div>
+        </div>
+
+        <div class="col-xs-12 col-md-4">
+
+          <div class="form-group">
+
+            <div class="checkbox">
+              <%= label_tag 'q_completed_at_not_null' do %>
+                <%= f.check_box :completed_at_not_null, {checked: @show_only_completed}, '1', '0' %>
+                <%= Spree.t(:show_only_complete_orders) %>
+              <% end %>
+            </div>
+
+            <div class="checkbox">
+              <%= label_tag 'q_considered_risky_eq' do %>
+                <%= f.check_box :considered_risky_eq, {checked: (params[:q][:considered_risky_eq] == '1')}, '1', '' %>
+                <%= Spree.t(:show_only_considered_risky) %>
+              <% end %>
+            </div>
+
+          </div>
+
+        </div>
+
+      </div>
+
+      <div data-hook="admin_orders_index_search_buttons" class="form-actions">
+        <%= button Spree.t(:filter_results), 'search' %>
+      </div>
+
+    <% end %>
+
+  </div>
+
+<% end %>
+
+<%= render 'spree/admin/shared/index_table_options', collection: @orders %>
+
+<% if @orders.any? %>
+  <table class="table" id="listing_orders" data-hook>
+    <thead>
+    <tr data-hook="admin_orders_index_headers">
+      <% if @show_only_completed %>
+        <th><%= sort_link @search, :completed_at,   I18n.t(:completed_at, scope: 'activerecord.attributes.spree/order') %></th>
+      <% else %>
+        <th><%= sort_link @search, :created_at,     I18n.t(:created_at, scope: 'activerecord.attributes.spree/order') %></th>
+      <% end %>
+      <th><%= sort_link @search, :number,           I18n.t(:number, scope: 'activerecord.attributes.spree/order') %></th>
+      <th><%= sort_link @search, :considered_risky, I18n.t(:considered_risky, scope: 'activerecord.attributes.spree/order') %></th>
+      <th><%= sort_link @search, :state,            I18n.t(:state, scope: 'activerecord.attributes.spree/order') %></th>
+      <th><%= sort_link @search, :payment_state,    I18n.t(:payment_state, scope: 'activerecord.attributes.spree/order') %></th>
+      <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+        <th><%= sort_link @search, :shipment_state, I18n.t(:shipment_state, scope: 'activerecord.attributes.spree/order') %></th>
+      <% end %>
+      <th><%= sort_link @search, :email,            I18n.t(:email, scope: 'activerecord.attributes.spree/order') %></th>
+      <th><%= sort_link @search, :total,            I18n.t(:total, scope: 'activerecord.attributes.spree/order') %></th>
+      <th data-hook="admin_orders_index_header_actions" class="actions"></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @orders.each do |order| %>
+      <tr data-hook="admin_orders_index_rows" class="state-<%= order.state.downcase %> <%= cycle('odd', 'even') %>">
+        <td>
+          <%= order_time(@show_only_completed ? order.completed_at : order.created_at) %>
+        </td>
+        <td><%= link_to order.number, edit_admin_order_path(order) %></td>
+        <td>
+          <span class="label label-<%= order.considered_risky ? 'considered_risky' : 'considered_safe' %>">
+            <%= order.considered_risky ? Spree.t("risky") : Spree.t("safe") %>
+          </span>
+        </td>
+        <td>
+          <span class="label label-<%= order.state.downcase %>"><%= Spree.t("order_state.#{order.state.downcase}") %></span>
+          <span class="icon icon-filter filterable js-add-filter" data-ransack-field="q_state_eq" data-ransack-value="<%= order.state %>"></span>
+        </td>
+        <td>
+          <% if order.payments.count > 0 && order.payments.last.source.present? %>
+            <% if order.payments.last.after_pay_method? && order.payments.last.authorized? %>
+              <span class="label label-authorized"><%= link_to 'authorized', admin_order_payments_path(order) %></span>
+            <% else %>
+              <span class="label label-<%= order.payments.last.source.status %>"><%= link_to order.payments.last.source.status, admin_order_payments_path(order) %></span>
+            <% end %>
+          <% end %>
+        </td>
+        <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+          <td>
+            <% if order.shipment_state %>
+              <span class="label label-<%= order.shipment_state %>"><%= Spree.t("shipment_states.#{order.shipment_state}") %></span>
+              <span class="icon icon-filter filterable js-add-filter" data-ransack-field="q_shipment_state_eq" data-ransack-value="<%= order.shipment_state %>"></span>
+            <% end %>
+          </td>
+        <% end %>
+        <td>
+          <% if order.user %>
+            <%= link_to order.email, edit_admin_user_path(order.user) %>
+          <% else %>
+            <%= mail_to order.email %>
+          <% end %>
+          <% if order.user || order.email %>
+            <span class="icon icon-filter filterable js-add-filter" data-ransack-field="q_email_cont" data-ransack-value="<%= order.email %>"></span>
+          <% end %>
+        </td>
+        <td><%= order.display_total.to_html %></td>
+        <td class='actions actions-1' data-hook="admin_orders_index_row_actions">
+          <%= link_to_edit_url edit_admin_order_path(order), title: "admin_edit_#{dom_id(order)}", no_text: true if can?(:edit, order) %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alert alert-info no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Order)) %>,
+    <%= link_to(Spree.t(:add_one), new_admin_order_url) if can? :create, Spree::Order %>!
+  </div>
+<% end %>
+
+<%= render 'spree/admin/shared/index_table_options', collection: @orders, simple: true %>

--- a/app/views/spree/admin/orders/index.html.erb
+++ b/app/views/spree/admin/orders/index.html.erb
@@ -234,3 +234,5 @@
 <% end %>
 
 <%= render 'spree/admin/shared/index_table_options', collection: @orders, simple: true %>
+
+<%= render 'spree/admin/shared/styles' %>

--- a/app/views/spree/admin/shared/_order_summary.html.erb
+++ b/app/views/spree/admin/shared/_order_summary.html.erb
@@ -1,0 +1,127 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title"><%= Spree.t(:summary) %></h3>
+  </div>
+
+  <table class="table table-condensed table-bordered" id="order_tab_summary" data-hook>
+    <tbody class="additional-info">
+    <tr>
+      <td id="order_status" width="35%" data-hook>
+        <strong><%= Spree.t(:status) %>:</strong>
+      </td>
+      <td>
+          <span class="state label label-<%= @order.state %>">
+            <%= Spree.t(@order.state, scope: :order_state) %>
+          </span>
+      </td>
+    </tr>
+    <tr>
+      <td data-hook='admin_order_tab_subtotal_title'>
+        <strong><%= Spree.t(:subtotal) %>:</strong>
+      </td>
+      <td id='item_total'>
+        <%= @order.display_item_total.to_html %>
+      </td>
+    </tr>
+
+    <% if @order.checkout_steps.include?("delivery") && @order.ship_total > 0 %>
+      <tr>
+        <td data-hook='admin_order_tab_ship_total_title'>
+          <strong><%= Spree.t(:ship_total) %>:</strong>
+        </td>
+        <td id='ship_total'>
+          <%= @order.display_ship_total.to_html %>
+        </td>
+      </tr>
+    <% end %>
+
+    <% if @order.included_tax_total != 0 %>
+      <tr>
+        <td data-hook='admin_order_tab_included_tax_title'>
+          <strong><%= Spree.t(:tax_included) %>:</strong>
+        </td>
+        <td id='included_tax_total'>
+          <%= @order.display_included_tax_total.to_html %>
+        </td>
+      </tr>
+    <% end %>
+
+    <% if @order.additional_tax_total != 0 %>
+      <tr>
+        <td data-hook='admin_order_tab_additional_tax_title'>
+          <strong><%= Spree.t(:tax) %>:</strong>
+        </td>
+        <td id='additional_tax_total'>
+          <%= @order.display_additional_tax_total.to_html %>
+        </td>
+      </tr>
+    <% end %>
+
+    <tr>
+      <td data-hook='admin_order_tab_total_title'>
+        <strong><%= Spree.t(:total) %>:</strong>
+      </td>
+      <td id='order_total'><%= @order.display_total.to_html %></td>
+    </tr>
+
+    <% if @order.completed? %>
+      <tr>
+        <td>
+          <strong><%= Spree.t(:shipment) %>:</strong>
+        </td>
+        <td id='shipment_status'>
+            <span class="state label label-<%= @order.shipment_state %>">
+              <%= Spree.t(@order.shipment_state, scope: :shipment_states, default: [:missing, "none"]) %>
+            </span>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <strong><%= Spree.t(:payment) %>:</strong>
+        </td>
+        <td id='payment_status'>
+          <% if @order.payments.count > 0 && @order.payments.last.source.present? %>
+            <% if @order.payments.last.after_pay_method? && @order.payments.last.authorized? %>
+              <span class="label label-authorized">authorized</span>
+            <% else %>
+              <span class="label label-<%= @order.payments.last.source.status %>"><%= @order.payments.last.source.status %></span>
+            <% end %>
+          <% end %>
+        </td>
+      </tr>
+      <tr>
+        <td data-hook='admin_order_tab_date_completed_title'>
+          <strong><%= Spree.t(:date_completed) %>:</strong>
+        </td>
+        <td id='date_complete'>
+          <%= pretty_time(@order.completed_at) %>
+        </td>
+      </tr>
+    <% end %>
+
+    <% if @order.approved? %>
+      <tr>
+        <td><strong><%= Spree.t(:approver) %></strong></td>
+        <td><%= @order.approver.try(:email) %></td>
+      </tr>
+      <tr>
+        <td><strong><%= Spree.t(:approved_at) %></strong></td>
+        <td><%= pretty_time(@order.approved_at) %></td>
+      </tr>
+    <% end %>
+
+    <% if @order.canceled? && @order.canceler && @order.canceled_at %>
+      <tr>
+        <td><strong><%= Spree.t(:canceler) %></strong></td>
+        <td><%= @order.canceler.email %></td>
+      </tr>
+      <tr>
+        <td><strong><%= Spree.t(:canceled_at) %></strong></td>
+        <td><%= pretty_time(@order.canceled_at) %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+
+<%= render 'spree/admin/shared/styles' %>

--- a/app/views/spree/admin/shared/_styles.html.erb
+++ b/app/views/spree/admin/shared/_styles.html.erb
@@ -1,0 +1,13 @@
+<style type="text/css">
+  .label.label-authorized {
+    background: orange;
+  }
+
+  .label.label-created {
+    background: #dcd2dd;
+  }
+
+  .label.label-created a {
+    color: #2E2F30;
+  }
+</style>


### PR DESCRIPTION
Merchants are confused by the "balance_due" status. Even though a payment has the state "pending", its balance is "balance_due". This makes it difficult for merchants to see if they can actually ship their order.

We should show "authorized" for payments whenever they are really authorized. 

We can assume that a payment is `authorized` when its source is a Mollie payment source, the payment method name is `klarnapaylater` or `klarnasliceit` and its status is `pending`. Mollie payment sources will only use the "pending" state for authorized payments.

**Note:** this is a temporary solution. We need to find a better way to show the Mollie payment status in the Spree admin by not having to overwrite the complete ERB file.