### PR TITLE
Check if order is already completed 

### DIFF
--- a/app/models/spree/mollie/payment_state_updater.rb
+++ b/app/models/spree/mollie/payment_state_updater.rb
@@ -63,6 +63,7 @@ module Spree
       end
 
       def complete_order!
+        return if @spree_payment.order.completed?
         @spree_payment.order.finalize!
         @spree_payment.order.update_attributes(state: 'complete', completed_at: Time.now)
         MollieLogger.debug('Order will be finalized and order confirmation will be sent.')


### PR DESCRIPTION
Check if an order is already completed before finalizing it multiple times on payment state transitions. 

Finalize is called on every transition to authorized or paid which calls the finalize method on the order.  