### PR TITLE
Add order refund for reimbursements

### DIFF
--- a/app/models/spree/gateway/mollie_gateway.rb
+++ b/app/models/spree/gateway/mollie_gateway.rb
@@ -99,7 +99,7 @@ module Spree
         if reimbursement
           mollie_order = ::Mollie::Order.get(payment.source.payment_id, {api_key: get_preference(:api_key)})
           mollie_order_refund_lines = reimbursement.return_items.map do |ri|
-            line = mollie_order.lines.detect {|line| line.sku == "#{ri.inventory_unit.line_item.id}-#{ri.variant.sku}"}
+            line = mollie_order.lines.detect {|line| line.sku == ri.inventory_unit.line_item.mollie_identifier}
             {id: line.id, quantity: ri.inventory_unit.line_item.quantity} if line
           end.compact
           mollie_order.refund!({lines: mollie_order_refund_lines, api_key: get_preference(:api_key)})

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -9,6 +9,10 @@ Spree::LineItem.class_eval do
     adjustments.tax.sum(:amount).abs
   end
 
+  def mollie_identifier
+    "#{line.id}-#{line.variant.sku}"
+  end
+
   def vat_rate
     if adjustments.tax.any?
       # Spree allows line items to have multiple TaxRate adjustments.

--- a/app/models/spree/mollie/order_serializer.rb
+++ b/app/models/spree/mollie/order_serializer.rb
@@ -193,7 +193,7 @@ module Spree
             value: format_money(line.display_vat_amount.money)
           },
           vatRate: line.vat_rate * 100,
-          sku: "#{line.id}-#{line.variant.sku}"
+          sku: line.mollie_identifier
         }
       end
     end


### PR DESCRIPTION
Refunds are an important part of the e-Commerce process. 

This PR includes refunding an x amount via the payments/*id*/refunds api when a regular refund is issued. This will not work for pay after delivery payment options. 

When processing a return by reimbursing a reimbursement with reimbursement action refund the orders/*orderId*/refunds endpoint will be used. This PR will find the items in the mollie order that are returned and issue a refund based on the return items in the reimbursement. 