### PR TITLE
Preserve order state when a payment expires on a paid order

### DIFF
--- a/app/models/spree/mollie/payment_state_updater.rb
+++ b/app/models/spree/mollie/payment_state_updater.rb
@@ -28,8 +28,12 @@ module Spree
           @spree_payment.source.update(status: @spree_payment.state)
         else
           MollieLogger.debug("Unhandled Mollie payment state received: #{@mollie_order.status}. Therefore we did not update the payment state.")
-          @spree_payment.order.update_attributes(state: 'payment', completed_at: nil)
+          unless @spree_payment.order.paid_or_authorized?
+            @spree_payment.order.update_attributes(state: 'payment', completed_at: nil)
+          end
         end
+
+        @spree_payment.order.update_with_updater!
       end
 
       private
@@ -48,7 +52,7 @@ module Spree
 
       def transition_to_failed!
         @spree_payment.failure! unless @spree_payment.failed?
-        @spree_payment.order.update_attributes(state: 'payment', completed_at: nil)
+        @spree_payment.order.update_attributes(state: 'payment', completed_at: nil) unless @spree_payment.order.paid_or_authorized?
         MollieLogger.debug("Mollie order is #{@mollie_order.status} and will be marked as failed")
       end
 


### PR DESCRIPTION
We observed that when people leave a payment link page to add something to their cart to later come back and create a new link, the old link causes some issues.

Since the payment link expires a callback will be issued. In the old situation this callback would reset the order to the payment state. But since the order has been paid for this is undesireable.

This PR prevents the order from being reset once its paid. Furthermore the order will be updated by the order updater after every state change since 1/10 orders did not update to their correct state after a callback. The shipment state would remain pending, hence stopping the order from moving forward in the process.