### PR TITLE
only create mollie shipment when the order is a mollie order

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -6,7 +6,10 @@ module Spree
 
     def after_ship
       super
-      create_mollie_shipment!
+
+      if order.is_paid_with_mollie?
+        create_mollie_shipment!
+      end
     end
 
     def create_mollie_shipment!

--- a/app/views/spree/api/v1/orders/complete.rabl
+++ b/app/views/spree/api/v1/orders/complete.rabl
@@ -1,0 +1,7 @@
+child available_payment_methods: :payment_methods do
+  attributes :id, :name, :method_type
+
+  node :gateways do |payment_method|
+    payment_method.gateways(order: @order) if @order.present?
+  end
+end

--- a/app/views/spree/api/v1/orders/complete.v1.rabl
+++ b/app/views/spree/api/v1/orders/complete.v1.rabl
@@ -1,7 +1,1 @@
-child available_payment_methods: :payment_methods do
-  attributes :id, :name, :method_type
-
-  node :gateways do |payment_method|
-    payment_method.gateways(order: @order) if @order.present?
-  end
-end
+extends 'spree/api/v1/orders/complete.rabl'

--- a/app/views/spree/api/v1/orders/payment.rabl
+++ b/app/views/spree/api/v1/orders/payment.rabl
@@ -1,0 +1,7 @@
+child available_payment_methods: :payment_methods do
+  attributes :id, :name, :method_type
+
+  node :gateways do |payment_method|
+    payment_method.gateways(order: @order) if @order.present?
+  end
+end

--- a/app/views/spree/api/v1/orders/payment.v1.rabl
+++ b/app/views/spree/api/v1/orders/payment.v1.rabl
@@ -1,7 +1,1 @@
-child available_payment_methods: :payment_methods do
-  attributes :id, :name, :method_type
-
-  node :gateways do |payment_method|
-    payment_method.gateways(order: @order) if @order.present?
-  end
-end
+extends 'spree/api/v1/orders/payment.rabl'


### PR DESCRIPTION
When the order is not paid with mollie the after_ship method should not attempts to create the mollie shipment. 
When attempting the flow fails because the payment source does not contain the mollie payment id. 

This PR solves this issue by checking if the order is paid with mollie before attempting to create a mollie shipment after_ship