### PR TITLE
create api templates with .rabl extension to comply with spree 4.0 co…

### DIFF
--- a/app/views/spree/api/v1/orders/complete.rabl
+++ b/app/views/spree/api/v1/orders/complete.rabl
@@ -1,0 +1,7 @@
+child available_payment_methods: :payment_methods do
+  attributes :id, :name, :method_type
+
+  node :gateways do |payment_method|
+    payment_method.gateways(order: @order) if @order.present?
+  end
+end

--- a/app/views/spree/api/v1/orders/complete.v1.rabl
+++ b/app/views/spree/api/v1/orders/complete.v1.rabl
@@ -1,7 +1,1 @@
-child available_payment_methods: :payment_methods do
-  attributes :id, :name, :method_type
-
-  node :gateways do |payment_method|
-    payment_method.gateways(order: @order) if @order.present?
-  end
-end
+extends 'spree/api/v1/orders/complete.rabl'

--- a/app/views/spree/api/v1/orders/payment.rabl
+++ b/app/views/spree/api/v1/orders/payment.rabl
@@ -1,0 +1,7 @@
+child available_payment_methods: :payment_methods do
+  attributes :id, :name, :method_type
+
+  node :gateways do |payment_method|
+    payment_method.gateways(order: @order) if @order.present?
+  end
+end

--- a/app/views/spree/api/v1/orders/payment.v1.rabl
+++ b/app/views/spree/api/v1/orders/payment.v1.rabl
@@ -1,7 +1,1 @@
-child available_payment_methods: :payment_methods do
-  attributes :id, :name, :method_type
-
-  node :gateways do |payment_method|
-    payment_method.gateways(order: @order) if @order.present?
-  end
-end
+extends 'spree/api/v1/orders/payment.rabl'


### PR DESCRIPTION
Change the naming of rabl templates to comply with the spree version 4.0 conventions