### PR TITLE
Don't create a Mollie customer when the gateway is inactive

### DIFF
--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -5,7 +5,7 @@ module Spree::UserDecorator
   end
 
   def ensure_mollie_customer
-    return if mollie_customer_id&.present?
+    return if try(:mollie_customer_id).present?
 
     # Don't create Mollie customers if spree_auth_devise is not installed.
     return unless defined? Spree::User

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -4,15 +4,14 @@ module Spree::UserDecorator
     base.after_commit :ensure_mollie_customer, on: %i[create update]
   end
 
-
   def ensure_mollie_customer
+    return if mollie_customer_id&.present?
+
     # Don't create Mollie customers if spree_auth_devise is not installed.
     return unless defined? Spree::User
 
     mollie_gateway = Spree::PaymentMethod.find_by_type 'Spree::Gateway::MollieGateway'
     return unless mollie_gateway&.active?
-
-    return if mollie_customer_id.present?
 
     mollie_customer = mollie_gateway.create_customer(self)
     update mollie_customer_id: mollie_customer.id

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,19 +1,18 @@
 module Spree::UserDecorator
 
   def self.prepended(base)
-    base.after_save :ensure_mollie_customer
+    base.after_commit :ensure_mollie_customer
   end
 
 
   def ensure_mollie_customer
-    # Don't create a Mollie customer if it has been created before
     return if mollie_customer_id.present?
 
     # Don't create Mollie customers if spree_auth_devise is not installed.
     return unless defined? Spree::User
 
     mollie_gateway = Spree::PaymentMethod.find_by_type 'Spree::Gateway::MollieGateway'
-    return unless mollie_gateway.present? && mollie_gateway.active?
+    return unless mollie_gateway&.active?
 
     mollie_customer = mollie_gateway.create_customer(self)
     update mollie_customer_id: mollie_customer.id

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,16 +1,19 @@
 module Spree::UserDecorator
 
   def self.prepended(base)
-    base.after_create :create_mollie_customer
+    base.after_save :ensure_mollie_customer
   end
 
 
-  def create_mollie_customer
+  def ensure_mollie_customer
+    # Don't create a Mollie customer if it has been created before
+    return if mollie_customer_id.present?
+
     # Don't create Mollie customers if spree_auth_devise is not installed.
     return unless defined? Spree::User
 
     mollie_gateway = Spree::PaymentMethod.find_by_type 'Spree::Gateway::MollieGateway'
-    return unless mollie_gateway.present?
+    return unless mollie_gateway.present? && mollie_gateway.active?
 
     mollie_customer = mollie_gateway.create_customer(self)
     update mollie_customer_id: mollie_customer.id

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,7 +1,7 @@
 module Spree::UserDecorator
 
   def self.prepended(base)
-    base.after_commit :ensure_mollie_customer
+    base.after_commit :ensure_mollie_customer, on: %i[create update]
   end
 
 

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -6,13 +6,13 @@ module Spree::UserDecorator
 
 
   def ensure_mollie_customer
-    return if mollie_customer_id.present?
-
     # Don't create Mollie customers if spree_auth_devise is not installed.
     return unless defined? Spree::User
 
     mollie_gateway = Spree::PaymentMethod.find_by_type 'Spree::Gateway::MollieGateway'
     return unless mollie_gateway&.active?
+
+    return if mollie_customer_id.present?
 
     mollie_customer = mollie_gateway.create_customer(self)
     update mollie_customer_id: mollie_customer.id


### PR DESCRIPTION
A client had invalid credentials in the Gateway settings which resulted in a Mollie::RequestError. Let's only create a Mollie customer when the gateway is active.

Using an ensure_mollie_customer after_save should also create Mollie customers for users that have been created in the time that is was inactive