### PR TITLE
Update mollie_controller.rb to set order_completed to true

### DIFF
--- a/app/controllers/spree/mollie_controller.rb
+++ b/app/controllers/spree/mollie_controller.rb
@@ -14,6 +14,8 @@ module Spree
       MollieLogger.debug("Redirect URL visited for order #{params[:order_number]}")
 
       order = order.reload
+      
+      flash['order_completed'] = order.completed?
 
       # Order is paid for or authorized (e.g. Klarna Pay Later)
       redirect_to order.paid? || payment.pending? ? order_path(order) : checkout_state_path(:payment)


### PR DESCRIPTION
I was missing another piece of code from the mollie gateway gem. 
Even though I did some edit in spree views, I'm still using there `order_just_completed?` method to display a thank you message.
This method needs `flash['order_completed']` to be true and is normally set in the checkout update action: 

https://github.com/spree/spree/blob/master/frontend/app/controllers/spree/checkout_controller.rb#L43

So, I'm guessing, setting it here to true would be a good thing to do. 

Wdyt?