### PR TITLE
Properly notify store owner when an order is completed

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -20,8 +20,9 @@ module Spree::OrderDecorator
 
     touch :completed_at
 
-    if !confirmation_delivered? && (paid? || authorized?)
-      deliver_order_confirmation_email
+    if (paid? || authorized?)
+      deliver_order_confirmation_email unless confirmation_delivered?
+      deliver_store_owner_order_notification_email if deliver_store_owner_order_notification_email?
     end
 
     consider_risk


### PR DESCRIPTION
Hi!

The "finalize!" method in the order_decorator.rb file was missing the `deliver_store_owner_order_notification_email` code. 

So... my store owners weren't receiving new order notifications, which is... pretty bad. 

This PR should fix the bug. 
Thanks!